### PR TITLE
Fix sourcemaps for nested files

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function(opt) {
       sourceRoot:     false,
       literate:       /\.(litcoffee|coffee\.md)$/.test(file.path),
       filename:       file.path,
-      sourceFiles:    [path.basename(file.path)],
+      sourceFiles:    [file.relative],
       generatedFile:  path.basename(dest)
     }, opt);
 


### PR DESCRIPTION
I noticed that source maps weren't working for nested files.

I used this directory structure:

```
src/
  some/deep/directory/
    one.cjsx
    two.cjsx
    three.jsx
  root.cjsx
```

with this gulpfile.js

``` js
var gulp = require('gulp');
var cjsx = require('gulp-cjsx');
var react = require('gulp-react');
var sourcemaps = require('gulp-sourcemaps');
var concat = require('gulp-concat');
var filter = require("gulp-filter");

var cjsxFilter = filter(["**/*.cjsx"], {restore: true})
var jsxFilter = filter(["**/*.jsx"], {restore: true})

gulp.task('build', function() {
  gulp.src(['src/root.cjsx', 'src/some/deep/**/*'], {base: 'src'})
    .pipe(sourcemaps.init())
    .pipe(cjsxFilter)
    .pipe(cjsx())
    .pipe(cjsxFilter.restore)
    .pipe(jsxFilter)
    .pipe(react())
    .pipe(jsxFilter.restore)
    .pipe(concat('bundle.js'))
    .pipe(sourcemaps.write('.', {debug: true}))
  .pipe(gulp.dest('dist'));
});

gulp.task('watch', function() {
  gulp.watch("src/**/*",  ["build"]);
});

gulp.task('default', ['build', 'watch']);

```

When you load it in the browser the source maps aren't present for the nested `cjsx` files, but they work for the nested `jsx` files. Also it isn't nesting the files correctly.

![](https://www.dropbox.com/s/mcy1lmkbn9hxpqa/Screenshot%202016-04-29%2017.06.07.png?dl=1)

I got this debug output from gulp-sourcemaps:

```
gulp-sourcemap-write: No source content for "root.cjsx". Loading from file.
gulp-sourcemap-write: No source content for "one.cjsx". Loading from file.
gulp-sourcemap-write: source file not found: /Users/crisco/Projects/test-sourcemaps-cjsx/src/one.cjsx
gulp-sourcemap-write: No source content for "some/deep/directory/three.jsx". Loading from file.
gulp-sourcemap-write: No source content for "two.cjsx". Loading from file.
gulp-sourcemap-write: source file not found: /Users/crisco/Projects/test-sourcemaps-cjsx/src/two.cjsx
```

I noticed the the `gulp-react` plugin was using file.relative for it's source files. After making that change to `gulp-cjsx` the source maps started working and the files are now grouped correctly:

![](https://www.dropbox.com/s/11gwd28luegpivl/Screenshot%202016-04-29%2017.18.50.png?dl=1)
